### PR TITLE
Require composer/installers.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,5 +2,8 @@
   "name": "pantheon-systems/quicksilver-pushback",
   "description": "Push commits made via the Pantheon dashboard back to original GitHub repository.",
   "type": "quicksilver-script",
+  "require": {
+    "composer/installers": "~1.0"
+  },
   "license": "MIT"
 }


### PR DESCRIPTION
Addresses #2 

Without this `"web/private/scripts/quicksilver/{$name}/": ["type:quicksilver-script"]` in `installer-paths` does not work properly.