### PR TITLE
Remove Debug Code

### DIFF
--- a/push-back-to-github.php
+++ b/push-back-to-github.php
@@ -11,6 +11,14 @@ if (!isset($_ENV['PANTHEON_ENVIRONMENT'])) {
   mkdir($workDir);
   $github_token = getenv('GITHUB_TOKEN');
 
+  if (false === $github_token) {
+    $bindingDir = $_SERVER['HOME'];
+    $privateFiles = "$bindingDir/files/private";
+    $gitHubSecretsFile = "$privateFiles/github-secrets.json";
+    $gitHubSecrets = load_github_secrets($gitHubSecretsFile);
+    $github_token = $gitHubSecrets['token'];
+  }
+
   $result = push_back_to_github($fullRepository, $workDir, $github_token);
 
   exit($result);

--- a/push-back-to-github.php
+++ b/push-back-to-github.php
@@ -2,30 +2,8 @@
 
 include __DIR__ . '/lean-repo-utils.php';
 
-// ad-hoc cli usage: call with cwd set to full repository
-// TODO: refactor for testability (and write tests!)
-if (!isset($_ENV['PANTHEON_ENVIRONMENT'])) {
-  $fullRepository = getcwd();
-  $workDir = sys_get_temp_dir() . '/pushback-workdir';
-  passthru("rm -rf $workDir");
-  mkdir($workDir);
-  $github_token = getenv('GITHUB_TOKEN');
-
-  if (false === $github_token) {
-    $bindingDir = $_SERVER['HOME'];
-    $privateFiles = "$bindingDir/files/private";
-    $gitHubSecretsFile = "$privateFiles/github-secrets.json";
-    $gitHubSecrets = load_github_secrets($gitHubSecretsFile);
-    $github_token = $gitHubSecrets['token'];
-  }
-
-  $result = push_back_to_github($fullRepository, $workDir, $github_token);
-
-  exit($result);
-}
-
-// Do nothing for test or live environments.
-if (in_array($_ENV['PANTHEON_ENVIRONMENT'], ['test', 'live'])) {
+// Do nothing if not on Pantheon or if on the test/live environments.
+if (!isset($_ENV['PANTHEON_ENVIRONMENT']) || in_array($_ENV['PANTHEON_ENVIRONMENT'], ['test', 'live']) ) {
   return;
 }
 


### PR DESCRIPTION
See #4. The code inside `if (!isset($_ENV['PANTHEON_ENVIRONMENT'])) {` is running on the build assets commit.

Attempting to load the GitHub secrets file from Pantheon if the `GITHUB_TOKEN` environment variable does not exist fixes the issue.

Full workflow watch output below

```
 [notice] Watching workflows...
 [notice] Finished workflow 7f25eed8-6ec8-11e7-8a39-bc764e10b0ce Create a Multidev environment () at 2017-07-22 10:29:52
 [notice] Started b3a7555c-6ec8-11e7-80b6-bc764e1022a9 Enable on-server development via SFTP for "ci-87" (ci-87) at 2017-07-22 10:29:54
 [notice] Finished workflow b3a7555c-6ec8-11e7-80b6-bc764e1022a9 Enable on-server development via SFTP for "ci-87" (ci-87) at 2017-07-22 10:30:03
 [notice] Started d5988ad2-6ec8-11e7-9477-bc764e10b0ce Sync code on "dev" (dev) at 2017-07-22 10:30:51
 [notice] Finished workflow d5988ad2-6ec8-11e7-9477-bc764e10b0ce Sync code on "dev" (dev) at 2017-07-22 10:31:06
 [notice] ------ Operation: Push changes back to GitHub if needed finished in 2s (dev) ------
Enter push-back-to-github. Repository root is /srv/bindings/4a1cba5445d24d2a95be4999973ab61b/code.
Could not find /srv/bindings/4a1cba5445d24d2a95be4999973ab61b/files/private/github-secrets.json

Notice: Undefined index: token in /srv/bindings/4a1cba5445d24d2a95be4999973ab61b/code/web/private/scripts/quicksilver/quicksilver-pushback/push-back-to-github.php on line 38
::::::::::::::::: Build Metadata :::::::::::::::::
array (
  'url' => 'git@github.com:pantheon-systems/example-wordpress-composer.git',
  'ref' => 'master',
  'sha' => '12bba7604fea9be169493db17b1653f7acf0f099',
  'comment' => 'Install Quicksilver Pushback script (#19)',
  'commit-date' => '2017-07-22 06:26:07 -0400',
  'build-date' => '2017-07-22 10:28:22 +0000',
)

::::::::::::::::: Info :::::::::::::::::
We are going to check out master from git@github.com:pantheon-systems/example-wordpress-composer.git, branch from 12bba7604fea9be169493db17b1653f7acf0f099 and cherry-pick b4475daf118f0c80cd56b7cdfaaece3e6dd1cc1a onto it
git clone git@github.com:pantheon-systems/example-wordpress-composer.git --depth=1 --branch master --single-branch
Cloning into '/srv/bindings/4a1cba5445d24d2a95be4999973ab61b/tmp/pushback-workdir/scratchRepository'...
Host key verification failed.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
git rev-parse HEAD
git fetch --unshallow
fatal: Cannot change to '/srv/bindings/4a1cba5445d24d2a95be4999973ab61b/tmp/pushback-workdir/scratchRepository': No such file or directory
Comment is 'Merge build assets from test ci-87.' and author is 'Circle CI <noreply@pantheon.io>' and date is '1500719448'
Creating a new branch, 'b4475master', because the master branch cannot be pushed to directly.
git checkout -B b4475master 12bba7604fea9be169493db17b1653f7acf0f099
fatal: Cannot change to '/srv/bindings/4a1cba5445d24d2a95be4999973ab61b/tmp/pushback-workdir/scratchRepository': No such file or directory

Warning: file_get_contents(/srv/bindings/4a1cba5445d24d2a95be4999973ab61b/tmp/pushback-workdir/scratchRepository/.gitignore): failed to open stream: No such file or directory in /srv/bindings/4a1cba5445d24d2a95be4999973ab61b/code/web/private/scripts/quicksilver/quicksilver-pushback/push-back-to-github.php on line 172

Warning: file_put_contents(/srv/bindings/4a1cba5445d24d2a95be4999973ab61b/code/.gitignore): failed to open stream: Permission denied in /srv/bindings/4a1cba5445d24d2a95be4999973ab61b/code/web/private/scripts/quicksilver/quicksilver-pushback/push-back-to-github.php on line 173
::::::::::::::::: .gitignore :::::::::::::::::

git add .
FAILED with 128
'git commit' did not add a commits. Status code: 128
 [notice] Started a345acaa-6ed1-11e7-8534-bc764e105ecb Create a Multidev environment () at 2017-07-22 11:33:52
 [notice] Finished workflow a345acaa-6ed1-11e7-8534-bc764e105ecb Create a Multidev environment () at 2017-07-22 11:35:19
 [notice] Started d7afb864-6ed1-11e7-bf93-bc764e105ecb Enable on-server development via SFTP for "pr-issue-4" (pr-issue-4) at 2017-07-22 11:35:20
 [notice] Finished workflow d7afb864-6ed1-11e7-bf93-bc764e105ecb Enable on-server development via SFTP for "pr-issue-4" (pr-issue-4) at 2017-07-22 11:35:28
```

========================= Updates in this PR deployed =========================

```
 [notice] Started 636c3bc0-6ed2-11e7-a842-bc764e11bdd3 Enable git push mode for "pr-issue-4" (pr-issue-4) at 2017-07-22 11:39:15
 [notice] Finished workflow 636c3bc0-6ed2-11e7-a842-bc764e11bdd3 Enable git push mode for "pr-issue-4" (pr-issue-4) at 2017-07-22 11:39:23
 [notice] Started 6a71a0e0-6ed2-11e7-bdb2-bc764e105ecb Sync code on "pr-issue-4" (pr-issue-4) at 2017-07-22 11:39:26
 [notice] Finished workflow 6a71a0e0-6ed2-11e7-bdb2-bc764e105ecb Sync code on "pr-issue-4" (pr-issue-4) at 2017-07-22 11:39:38
 [notice] ------ Operation: Push changes back to GitHub if needed finished in 1s (pr-issue-4) ------
Enter push-back-to-github. Repository root is /srv/bindings/ff52046a1cc14d589e1c5ec259b11b70/code.
::::::::::::::::: Build Metadata :::::::::::::::::
array (
  'url' => 'git@github.com:pantheon-systems/example-wordpress-composer.git',
  'ref' => 'issue-4-quicksilver-pushback',
  'sha' => 'a32c7ae8960cc3620c8fad55d2a2797cd100ca72',
  'comment' => 'Testing issue-4-missing-secrets-file branch of Quicksilver Pushback',
  'commit-date' => '2017-07-22 07:31:36 -0400',
  'build-date' => '2017-07-22 11:39:15 +0000',
)

Ignoring commit because it contains build assets.

 [notice] Started 76a38cfc-6ed2-11e7-a8fb-bc764e10d7c2 Clone database to "pr-issue-4" (pr-issue-4) at 2017-07-22 11:39:47
 [notice] Started 757a49b0-6ed2-11e7-ac68-bc764e1022a9 Clone files to "pr-issue-4" (pr-issue-4) at 2017-07-22 11:39:45
 [notice] Finished workflow 757a49b0-6ed2-11e7-ac68-bc764e1022a9 Clone files to "pr-issue-4" (pr-issue-4) at 2017-07-22 11:39:46
 [notice] Finished workflow 76a38cfc-6ed2-11e7-a8fb-bc764e10d7c2 Clone database to "pr-issue-4" (pr-issue-4) at 2017-07-22 11:39:53
 [notice] Started 7adfa85a-6ed2-11e7-bb98-bc764e11bdd3 Enable on-server development via SFTP for "pr-issue-4" (pr-issue-4) at 2017-07-22 11:39:54
 [notice] Finished workflow 7adfa85a-6ed2-11e7-bb98-bc764e11bdd3 Enable on-server development via SFTP for "pr-issue-4" (pr-issue-4) at 2017-07-22 11:40:02
```