### PR TITLE
BUGS-3487 OSD not getting pushed back to canonical repository due to malformed git commit author

### DIFF
--- a/lean-repo-utils.php
+++ b/lean-repo-utils.php
@@ -158,7 +158,7 @@ function push_back($fullRepository, $workDir, $upstreamRepoWithCredentials, $bui
     $commit_date = escapeshellarg(exec("git -C $fullRepository log -1 --pretty=\"%at\""));
     $author_name = exec("git -C $fullRepository log -1 --pretty=\"%an\"");
     $author_email = exec("git -C $fullRepository log -1 --pretty=\"%ae\"");
-    $author = escapeshellarg("$author_name <$author_email>");
+    $author = "$author_name <$author_email>";
 
     print "Comment is $comment and author is $author and date is $commit_date\n";
     // Make a safe space to store stuff
@@ -213,7 +213,9 @@ function push_back($fullRepository, $workDir, $upstreamRepoWithCredentials, $bui
     // We don't want to commit the build-metadata to the canonical repository.
     passthru("git --git-dir=$canonicalRepository/.git -C $fullRepository reset HEAD $buildMetadataFile");
     // TODO: Copy author, message and perhaps other attributes from the commit at the head of the full repository
-    passthru("git --git-dir=$canonicalRepository/.git -C $fullRepository commit -q --no-edit --message=$comment --author=$author --date=$commit_date", $commitStatus);
+    passthru("git --git-dir=$canonicalRepository/.git -C $fullRepository config user.name ".escapeshellarg($author_name));
+    passthru("git --git-dir=$canonicalRepository/.git -C $fullRepository config user.email ".escapeshellarg($author_email));
+    passthru("git --git-dir=$canonicalRepository/.git -C $fullRepository commit -q --no-edit --message=$comment  --date=$commit_date", $commitStatus);
 
     // Get our .gitignore back
     passthru("git -C $fullRepository checkout -- .gitignore");


### PR DESCRIPTION
This fixes the missing email causing git commit to fail. Somehow escapeshellarg is stripping the email part.

**Manual testing**

```
git checkout -b qs-pushback-test
composer config repositories.qs vcs https://github.com/marfillaster/quicksilver-pushback
composer config minimum-stability dev
```

Edit composer.json
```diff
-  "pantheon-systems/quicksilver-pushback": "^2",
+  "pantheon-systems/quicksilver-pushback": "dev-authorfix as 2.0.1",
```
Update composer and commit composer.json and composer.lock
```
composer update
git add composer.json composer.lock
git commit
```