### PR TITLE
[CMS-613] Add git user config if empty and improve commit debugging.

### DIFF
--- a/lean-repo-utils.php
+++ b/lean-repo-utils.php
@@ -212,8 +212,18 @@ function push_back($fullRepository, $workDir, $upstreamRepoWithCredentials, $bui
     }
     // We don't want to commit the build-metadata to the canonical repository.
     passthru("git --git-dir=$canonicalRepository/.git -C $fullRepository reset HEAD $buildMetadataFile");
+
+    $userName = exec("git --git-dir=$canonicalRepository/.git -C $fullRepository config user.name");
+    if (empty($userName)) {
+        passthru("git --git-dir=$canonicalRepository/.git -C $fullRepository config user.name 'Pantheon'");
+    }
+    $userEmail = exec("git --git-dir=$canonicalRepository/.git -C $fullRepository config user.email");
+    if (empty($userEmail)) {
+        passthru("git --git-dir=$canonicalRepository/.git -C $fullRepository config user.email 'bot@getpantheon.com'");
+    }
+
     // TODO: Copy author, message and perhaps other attributes from the commit at the head of the full repository
-    passthru("git --git-dir=$canonicalRepository/.git -C $fullRepository commit -q --no-edit --message=$comment --author=$author --date=$commit_date", $commitStatus);
+    passthru("git --git-dir=$canonicalRepository/.git -C $fullRepository commit --no-edit --message=$comment --author=$author --date=$commit_date 2>&1", $commitStatus);
 
     // Get our .gitignore back
     passthru("git -C $fullRepository checkout -- .gitignore");

--- a/lean-repo-utils.php
+++ b/lean-repo-utils.php
@@ -211,7 +211,7 @@ function push_back($fullRepository, $workDir, $upstreamRepoWithCredentials, $bui
         print "FAILED with $status\n";
     }
     // We don't want to commit the build-metadata to the canonical repository.
-    passthru("git --git-dir=$canonicalRepository/.git -C $fullRepository reset HEAD $buildMetadataFile bash_env.txt dev-master");
+    passthru("git --git-dir=$canonicalRepository/.git -C $fullRepository reset HEAD $buildMetadataFile");
 
     $userName = exec("git --git-dir=$canonicalRepository/.git -C $fullRepository config user.name");
     if (empty($userName)) {

--- a/lean-repo-utils.php
+++ b/lean-repo-utils.php
@@ -211,7 +211,7 @@ function push_back($fullRepository, $workDir, $upstreamRepoWithCredentials, $bui
         print "FAILED with $status\n";
     }
     // We don't want to commit the build-metadata to the canonical repository.
-    passthru("git --git-dir=$canonicalRepository/.git -C $fullRepository reset HEAD $buildMetadataFile");
+    passthru("git --git-dir=$canonicalRepository/.git -C $fullRepository reset HEAD $buildMetadataFile bash_env.txt dev-master");
 
     $userName = exec("git --git-dir=$canonicalRepository/.git -C $fullRepository config user.name");
     if (empty($userName)) {
@@ -223,7 +223,7 @@ function push_back($fullRepository, $workDir, $upstreamRepoWithCredentials, $bui
     }
 
     // TODO: Copy author, message and perhaps other attributes from the commit at the head of the full repository
-    passthru("git --git-dir=$canonicalRepository/.git -C $fullRepository commit --no-edit --message=$comment --author=$author --date=$commit_date 2>&1", $commitStatus);
+    passthru("git --git-dir=$canonicalRepository/.git -C $fullRepository commit -q --no-edit --message=$comment --author=$author --date=$commit_date 2>&1", $commitStatus);
 
     // Get our .gitignore back
     passthru("git -C $fullRepository checkout -- .gitignore");


### PR DESCRIPTION
During my tests it was empty and therefore failing. Let's ensure it has valid values.