### PR TITLE
fix(DELENG-621): Fix service-catalog workflow jobs skipped on slash branches

### DIFF
--- a/.github/workflows/service-catalog.yaml
+++ b/.github/workflows/service-catalog.yaml
@@ -12,18 +12,17 @@ permissions:
   id-token: "write"
 jobs:
   docs:
-    if: "!contains(github.ref_name, '/')"
-    # SHA: 436c9e4b5ba68282956ffa169ae714827cf49bc5
-    # Source: service-catalog PR #113 merge commit (main branch, 2026-02-23)
+    # SHA: efb692da7567baea9f08d75419df5455a7f6fdec
+    # Source: service-catalog PR #126 merge commit (main branch, 2026-06-11)
     # Allowlisted in: projects/pantheon-wif/workload-identity-federation.tf
     # See: https://github.com/pantheon-systems/gce-terraform/blob/master/projects/pantheon-wif/workload-identity-federation.tf#L106
-    uses: pantheon-systems/service-catalog/.github/workflows/docs-like-code.yaml@efb692da7567baea9f08d75419df5455a7f6fdec  # main 2026-02-23T15:36:38Z
+    uses: pantheon-systems/service-catalog/.github/workflows/docs-like-code.yaml@efb692da7567baea9f08d75419df5455a7f6fdec  # main 2026-06-11
   catalog-upload:
-    if: "!contains(github.ref_name, '/')"
-    # SHA: 436c9e4b5ba68282956ffa169ae714827cf49bc5
-    # Source: service-catalog PR #113 merge commit (main branch, 2026-02-23)
+    if: github.ref_name == 'main'
+    # SHA: efb692da7567baea9f08d75419df5455a7f6fdec
+    # Source: service-catalog PR #126 merge commit (main branch, 2026-06-11)
     # This SHA is allowlisted in the pantheon-service-catalog WIF pool for production classification
     # Allowlist location: projects/pantheon-wif/workload-identity-federation.tf (attribute.jwr_repo_file_env)
     # See: https://github.com/pantheon-systems/gce-terraform/blob/master/projects/pantheon-wif/workload-identity-federation.tf#L106
-    uses: pantheon-systems/service-catalog/.github/workflows/catalog-upload.yaml@efb692da7567baea9f08d75419df5455a7f6fdec  # main 2026-02-23T15:36:38Z
+    uses: pantheon-systems/service-catalog/.github/workflows/catalog-upload.yaml@efb692da7567baea9f08d75419df5455a7f6fdec  # main 2026-06-11
 # DELENG-621 CI trigger


### PR DESCRIPTION
## Problem

Both jobs in `service-catalog.yaml` had `if: "!contains(github.ref_name, '/')"`. This condition is `false` for any branch name containing a `/` — including standard feature branches like `fix/bump-service-catalog-sha`. As a result, both the `docs` and `catalog-upload` jobs were silently skipped on every PR, making the test plan unverifiable from a slash-named branch.

This was the root cause behind PR #33's test plan item ("Verify `docs` and `catalog-upload` jobs pass on this PR") being impossible to satisfy — the workflow was triggered by the `pull_request` event, but zero jobs ever started.

## Fix

- **`docs` job**: Remove the `if` condition entirely. The `docs-like-code.yaml` reusable workflow handles its own publish logic internally (it already gates on `github.actor != 'dependabot[bot]'` and uses branch-aware publish behavior).
- **`catalog-upload` job**: Replace `!contains(github.ref_name, '/')` with the explicit `github.ref_name == 'main'`. Catalog uploads should only happen post-merge, and this makes that intent unambiguous.
- **Stale comments**: Update SHA source references from PR #113 to PR #126.

## Test plan

- [ ] Verify `docs` job runs (not skipped) on this PR
- [ ] Verify `catalog-upload` job is skipped on this PR (expected — only runs on main)
- [ ] Verify both jobs run after merge to main

Jira: https://getpantheon.atlassian.net/browse/DELENG-621